### PR TITLE
feat: add web ui confirmation dialog

### DIFF
--- a/conversation_handler.py
+++ b/conversation_handler.py
@@ -16,6 +16,7 @@ class ConversationHandler:
         self.profile_manager = ProfileManager()
         self.chat_session = start_chat_session()
         self.last_critique = "角色档案为空，请引导用户描述角色的核心身份。"
+        self.confirmation_shown = False
         
     def get_initial_greeting(self):
         """
@@ -39,11 +40,11 @@ class ConversationHandler:
             if full_profile:
                 evaluation = evaluate_profile(full_profile)
                 self.last_critique = evaluation.get("critique", self.last_critique)
-                
-                if evaluation.get("is_ready_for_writing", False):
+
+                if evaluation.get("is_ready_for_writing", False) and not self.confirmation_shown:
                     confirmation_reason = evaluation.get("critique", "角色档案似乎已足够完整。")
                     yield f"CONFIRM_GENERATION::{confirmation_reason}"
-                    return
+                    self.confirmation_shown = True
 
         # Get the generator for the streaming response
         response_generator = get_conversation_response_stream(self.chat_session, message, self.last_critique)

--- a/web-client/app.js
+++ b/web-client/app.js
@@ -1,0 +1,64 @@
+const chat = document.getElementById('chat');
+const input = document.getElementById('user-input');
+const sendBtn = document.getElementById('send');
+const dialog = document.getElementById('floating-dialog');
+const dialogMsg = document.getElementById('dialog-message');
+const confirmBtn = document.getElementById('confirm-generate');
+const ignoreBtn = document.getElementById('ignore-dialog');
+
+const ws = new WebSocket(`ws://${location.host}/ws/prompt`);
+
+function appendMessage(sender, message) {
+    const div = document.createElement('div');
+    div.textContent = `${sender}: ${message}`;
+    chat.appendChild(div);
+    chat.scrollTop = chat.scrollHeight;
+}
+
+ws.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    const { type, payload } = data;
+
+    switch (type) {
+        case 'system_message':
+            appendMessage('系统', payload.message);
+            break;
+        case 'ai_response_chunk':
+            appendMessage('AI', payload.chunk);
+            break;
+        case 'evaluation_update':
+            if (payload.message) {
+                appendMessage('评估', payload.message);
+            }
+            break;
+        case 'confirmation_request':
+            dialogMsg.textContent = payload.reason || '档案已准备好，是否生成 Prompt?';
+            dialog.style.display = 'block';
+            break;
+        case 'final_prompt_chunk':
+            appendMessage('Prompt', payload.chunk);
+            break;
+        case 'session_end':
+            appendMessage('系统', payload.message);
+            ws.close();
+            break;
+    }
+};
+
+sendBtn.onclick = () => {
+    const text = input.value.trim();
+    if (!text) return;
+    ws.send(JSON.stringify({ type: 'user_response', payload: { answer: text } }));
+    appendMessage('你', text);
+    input.value = '';
+};
+
+confirmBtn.onclick = () => {
+    ws.send(JSON.stringify({ type: 'user_confirmation', payload: { confirm: true } }));
+    dialog.style.display = 'none';
+};
+
+ignoreBtn.onclick = () => {
+    ws.send(JSON.stringify({ type: 'user_confirmation', payload: { confirm: false } }));
+    dialog.style.display = 'none';
+};

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>Easy Prompt</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+        #chat { height: 60vh; overflow-y: auto; border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
+        #floating-dialog { position: fixed; top: 20px; right: 20px; background: #fff; border: 1px solid #333; padding: 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); display: none; z-index: 1000; }
+        #floating-dialog button { margin-right: 5px; }
+    </style>
+</head>
+<body>
+    <div id="chat"></div>
+    <input id="user-input" type="text" placeholder="输入消息"/>
+    <button id="send">发送</button>
+
+    <div id="floating-dialog">
+        <p id="dialog-message"></p>
+        <button id="confirm-generate">生成 Prompt</button>
+        <button id="ignore-dialog">继续对话</button>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow conversations to continue after evaluation and show confirmation once
- add minimal web UI with floating dialog to confirm or skip prompt generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689717e965f0832dbf3aa7d08866d774